### PR TITLE
Fix for filenames with dots in them

### DIFF
--- a/glitch_this.py
+++ b/glitch_this.py
@@ -202,7 +202,7 @@ if __name__ == '__main__':
     pixel_tuple_len = len(src_img.getbands())
     img_width, img_height = src_img.size
     img_path, img_file = os.path.split(src_img_path)
-    img_filename, img_fileex = img_file.split('.')
+    img_filename, img_fileex = img_file.rsplit('.', 1)
     img_mode = src_img.mode
 
     # Creating 3D arrays with pixel data


### PR DESCRIPTION
Currently if you try to process a file that has a dot in the filename, the script fails:
```
ojensen@qenie:~/bin/repos/glitch-this$ python3 glitch_this.py ~/4.1581136753.png 2
Traceback (most recent call last):
  File "glitch_this.py", line 205, in <module>
    img_filename, img_fileex = img_file.split('.')
ValueError: too many values to unpack (expected 2)
```

This PR fixes it :)