### PR TITLE
Update shebang to reflect documentation/best-practice

### DIFF
--- a/glitch_this.py
+++ b/glitch_this.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os, argparse, shutil
 import numpy as np
 from pathlib import Path


### PR DESCRIPTION
The shebang for python 3 should be: #!/usr/bin/env python3

This is also mentioned in the documentation, since "python" can still link to both, python2 and python3.