### PR TITLE
Output each frame separately

### DIFF
--- a/glitch_this/commandline.py
+++ b/glitch_this/commandline.py
@@ -164,10 +164,8 @@ def main():
     # If output type is frames, we need to check if files exist for each frame
     if args.output_frames:
         for i in range(args.frames):
-            frame_path = (
-                f"{full_path.rsplit('.', 1)[0]}_{i}.{
-                    full_path.rsplit('.', 1)[1]}"
-            )
+            frame_path = os.path.join(
+                out_path, (f"{out_filename}_{i}.{out_fileex}"))
             if os.path.exists(frame_path) and not args.force:
                 raise Exception(
                     frame_path + " already exists\nCannot overwrite "
@@ -235,14 +233,11 @@ def main():
         )
     else:
         for i, frame in enumerate(glitch_img):
-            frame_path = (
-                f"{full_path.rsplit('.', 1)[0]}_{i}.{
-                    full_path.rsplit('.', 1)[1]}"
-            )
+            frame_path = os.path.join(
+                out_path, (f"{out_filename}_{i}.{out_fileex}"))
             frame.save(frame_path, compress_level=3)
         t3 = time()
-        print(f'Glitched frames saved in "{
-              full_path.rsplit(".", 1)[0]}_*.png"')
+        print(f'Glitched frames saved in "{out_filename}_*.png"')
     print(f"Time taken to glitch: {t1 - t0}")
     print(f"Time taken to save: {t3 - t2}")
     print(f"Total Time taken: {t3 - t0}")

--- a/glitch_this/commandline.py
+++ b/glitch_this/commandline.py
@@ -71,6 +71,8 @@ def get_help(glitch_min: float, glitch_max: float) -> Dict:
     help_text['inputgif'] = 'Include if input image is GIF'
     help_text['force'] = 'Forcefully overwrite output file'
     help_text['out'] = 'Explcitly supply full/relative path to output file'
+    help_text["output_frames"] = "Output individual frames of the glitched GIF as separate images"
+
     return help_text
 
 
@@ -118,6 +120,8 @@ def main():
                            help=help_text['loop'])
     argparser.add_argument('-o', '--outfile', dest='outfile', metavar='Outfile_path', type=str,
                            help=help_text['out'])
+    argparser.add_argument("-of", "--output-frames", dest="output_frames",
+                           action="store_true", help=help_text["output_frames"])
     args = argparser.parse_args()
 
     # Sanity check inputs
@@ -129,27 +133,52 @@ def main():
         raise ValueError('Frames must be greater than 0')
     if not os.path.isfile(args.src_img_path):
         raise FileNotFoundError('No image found at given path')
+    if args.output_frames and not args.gif:
+        raise ValueError("Cannot output frames without GIF output enabled")
 
     # Set up full_path, for output saving location
     out_path, out_file = os.path.split(Path(args.src_img_path))
     out_filename, out_fileex = out_file.rsplit('.', 1)
     out_filename = 'glitched_' + out_filename
     # Output file extension should be '.gif' if output file is going to be a gif
-    out_fileex = 'gif' if args.gif else out_fileex
+    if args.gif:
+        out_fileex = "gif"
+    elif args.output_frames:
+        out_fileex = "png"
+    else:
+        out_fileex = out_fileex
+
     if args.outfile:
         # If output file path is already given
         # Overwrite the previous values
         out_path, out_file = os.path.split(Path(args.outfile))
-        if out_path != '' and not os.path.exists(out_path):
-            raise Exception('Given outfile path, ' +
-                            out_path + ', does not exist')
+        if out_path != "" and not os.path.exists(out_path):
+            raise Exception("Given outfile path, " +
+                            out_path + ", does not exist")
         # The extension in user provided outfile path is ignored
-        out_filename = out_file.rsplit('.', 1)[0]
+        out_filename = out_file.rsplit(".", 1)[0]
+
     # Now create the full path
-    full_path = os.path.join(out_path, f'{out_filename}.{out_fileex}')
-    if os.path.exists(full_path) and not args.force:
-        raise Exception(full_path + ' already exists\nCannot overwrite '
-                        'existing file unless -f or --force is included\nProgram Aborted')
+    full_path = os.path.join(out_path, f"{out_filename}.{out_fileex}")
+
+    # If output type is frames, we need to check if files exist for each frame
+    if args.output_frames:
+        for i in range(args.frames):
+            frame_path = (
+                f"{full_path.rsplit('.', 1)[0]}_{i}.{
+                    full_path.rsplit('.', 1)[1]}"
+            )
+            if os.path.exists(frame_path) and not args.force:
+                raise Exception(
+                    frame_path + " already exists\nCannot overwrite "
+                    "existing file unless -f or --force is included\nProgram Aborted"
+                )
+    else:
+        if os.path.exists(full_path) and not args.force:
+            raise Exception(
+                full_path + " already exists\nCannot overwrite "
+                "existing file unless -f or --force is included\nProgram Aborted"
+            )
 
     # Actual work begins here
     glitcher = ImageGlitcher()
@@ -189,20 +218,34 @@ def main():
         glitch_img.save(full_path, compress_level=3)
         t3 = time()
         print('Glitched Image saved in "{}"'.format(full_path))
-    else:
-        glitch_img[0].save(full_path,
-                           format='GIF',
-                           append_images=glitch_img[1:],
-                           save_all=True,
-                           duration=args.duration,
-                           loop=args.loop,
-                           compress_level=3)
+    elif not args.output_frames:
+        glitch_img[0].save(
+            full_path,
+            format="GIF",
+            append_images=glitch_img[1:],
+            save_all=True,
+            duration=args.duration,
+            loop=args.loop,
+            compress_level=3,
+        )
         t3 = time()
         print(
-            f'Glitched GIF saved in "{full_path}"\nFrames = {args.frames}, Duration = {args.duration}, Loop = {args.loop}')
-    print(f'Time taken to glitch: {t1 - t0}')
-    print(f'Time taken to save: {t3 - t2}')
-    print(f'Total Time taken: {t3 - t0}')
+            f'Glitched GIF saved in "{full_path}"\nFrames = {
+                args.frames}, Duration = {args.duration}, Loop = {args.loop}'
+        )
+    else:
+        for i, frame in enumerate(glitch_img):
+            frame_path = (
+                f"{full_path.rsplit('.', 1)[0]}_{i}.{
+                    full_path.rsplit('.', 1)[1]}"
+            )
+            frame.save(frame_path, compress_level=3)
+        t3 = time()
+        print(f'Glitched frames saved in "{
+              full_path.rsplit(".", 1)[0]}_*.png"')
+    print(f"Time taken to glitch: {t1 - t0}")
+    print(f"Time taken to save: {t3 - t2}")
+    print(f"Total Time taken: {t3 - t0}")
 
     # Let the user know if new version is available
     if not is_latest(current_version):

--- a/glitch_this/commandline.py
+++ b/glitch_this/commandline.py
@@ -54,7 +54,8 @@ def is_latest(version: str) -> bool:
 def get_help(glitch_min: float, glitch_max: float) -> Dict:
     help_text = dict()
     help_text['path'] = 'Relative or Absolute string path to source image'
-    help_text['level'] = f'Number between {glitch_min} and {glitch_max}, inclusive, representing amount of glitchiness'
+    help_text['level'] = f'Number between {glitch_min} and {
+        glitch_max}, inclusive, representing amount of glitchiness'
     help_text['color'] = 'Include if you want to add color offset'
     help_text['scan'] = 'Include if you want to add scan lines effect\nDefaults to False'
     help_text['seed'] = 'Set a random seed for generating similar images across runs'
@@ -62,7 +63,8 @@ def get_help(glitch_min: float, glitch_max: float) -> Dict:
     help_text['frames'] = 'Number of frames to include in output GIF, default - 23'
     help_text['step'] = 'Glitch every step\'th frame of output GIF, default - 1 (every frame)'
     help_text['increment'] = 'Increment glitch_amount by given value after glitching every frame of output GIF'
-    help_text['cycle'] = f'Include if glitch_amount should be cycled back to {glitch_min} or {glitch_max} if it over/underflows'
+    help_text['cycle'] = f'Include if glitch_amount should be cycled back to {
+        glitch_min} or {glitch_max} if it over/underflows'
     help_text['duration'] = 'How long to display each frame (in centiseconds), default - 200'
     help_text['relative_duration'] = 'Multiply given value to input GIF\'s original duration and use that as duration'
     help_text['loop'] = 'How many times the glitched GIF should loop, default - 0 (infinite loop)'
@@ -205,6 +207,7 @@ def main():
     # Let the user know if new version is available
     if not is_latest(current_version):
         print('A new version of "glitch-this" is available. Please consider upgrading via `pip3 install --upgrade glitch-this`')
+
 
 if __name__ == '__main__':
     main()

--- a/test_script.py
+++ b/test_script.py
@@ -35,7 +35,7 @@ def test_loop():
     timesum = 0
     try:
         with open('Collections/imglog.txt', 'w') as logtxt:
-            while(1):
+            while (1):
                 t0 = time()
                 level = choice(amount_list)
                 """
@@ -85,13 +85,15 @@ def test_image_to_image():
     glitch_img.save(f'Collections/glitched_test_seed.{fmt}')
 
     # How about all of them?
-    glitch_img = glitcher.glitch_image(f'test.{fmt}', 2, color_offset=True, scan_lines=True, seed=42)
+    glitch_img = glitcher.glitch_image(
+        f'test.{fmt}', 2, color_offset=True, scan_lines=True, seed=42)
     glitch_img.save(f'Collections/glitched_test_all.{fmt}')
 
     # You can also pass an Image object inplace of the path
     # Applicable in all of the examples above
     img = Image.open(f'test.{fmt}')
-    glitch_img = glitcher.glitch_image(img, 2, color_offset=True, scan_lines=True, seed=42)
+    glitch_img = glitcher.glitch_image(
+        img, 2, color_offset=True, scan_lines=True, seed=42)
     glitch_img.save(f'Collections/glitched_test_all_obj.{fmt}')
 
 
@@ -123,7 +125,8 @@ def test_image_to_gif():
                         loop=LOOP)
 
     # Now try with scan_lines set to true
-    glitch_imgs = glitcher.glitch_image(f'test.{fmt}', 2, gif=True, scan_lines=True)
+    glitch_imgs = glitcher.glitch_image(
+        f'test.{fmt}', 2, gif=True, scan_lines=True)
     glitch_imgs[0].save('Collections/glitched_test_scan.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],
@@ -132,7 +135,8 @@ def test_image_to_gif():
                         loop=LOOP)
 
     # Now try with color_offset set to true
-    glitch_imgs = glitcher.glitch_image(f'test.{fmt}', 2, gif=True, color_offset=True)
+    glitch_imgs = glitcher.glitch_image(
+        f'test.{fmt}', 2, gif=True, color_offset=True)
     glitch_imgs[0].save('Collections/glitched_test_color.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],
@@ -153,7 +157,8 @@ def test_image_to_gif():
     # glitch_amount will reach glitch_max after (glitch_max - glitch_amount)/glitch_change glitches
     # in this case that's 8
     # It'll just stay at glitch_max for the remaining duration since cycle = False
-    glitch_imgs = glitcher.glitch_image(f'test.{fmt}', 2, glitch_change=1, gif=True)
+    glitch_imgs = glitcher.glitch_image(
+        f'test.{fmt}', 2, glitch_change=1, gif=True)
     glitch_imgs[0].save('Collections/glitched_test_increment.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],
@@ -165,7 +170,8 @@ def test_image_to_gif():
     # glitch_amount will reach glitch_max after (glitch_max - glitch_amount)/glitch_change glitches
     # in this case that's 8
     # It'll cycle back to glitch_min after that and keep incrementing by glitch_change again
-    glitch_imgs = glitcher.glitch_image(f'test.{fmt}', 2, glitch_change=1, cycle=True, gif=True)
+    glitch_imgs = glitcher.glitch_image(
+        f'test.{fmt}', 2, glitch_change=1, cycle=True, gif=True)
     glitch_imgs[0].save('Collections/glitched_test_increment_cycle.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],
@@ -178,7 +184,8 @@ def test_image_to_gif():
     # in this case that's 1
     # It'll cycle back to glitch_max after that and keep incrementing (actually decrementing, in this case)
     # by glitch_change again
-    glitch_imgs = glitcher.glitch_image(f'test.{fmt}', 2, glitch_change=-1, cycle=True, gif=True)
+    glitch_imgs = glitcher.glitch_image(
+        f'test.{fmt}', 2, glitch_change=-1, cycle=True, gif=True)
     glitch_imgs[0].save('Collections/glitched_test_decrement_cycle.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],
@@ -248,7 +255,8 @@ def test_gif_to_gif():
                         duration=DURATION,
                         loop=LOOP)
     # Now try with scan_lines set to true
-    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif('test.gif', 2, scan_lines=True)
+    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif(
+        'test.gif', 2, scan_lines=True)
     glitch_imgs[0].save('Collections/glitched_gif_scan.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],
@@ -257,7 +265,8 @@ def test_gif_to_gif():
                         loop=LOOP)
 
     # Now try with color_offset set to true
-    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif('test.gif', 2, color_offset=True)
+    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif(
+        'test.gif', 2, color_offset=True)
     glitch_imgs[0].save('Collections/glitched_gif_color.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],
@@ -269,7 +278,8 @@ def test_gif_to_gif():
     # glitch_amount will reach glitch_max after (glitch_max - glitch_amount)/glitch_change glitches
     # in this case that's 8
     # It'll just stay at glitch_max for the remaining duration since cycle = False
-    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif('test.gif', 2, glitch_change=1)
+    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif(
+        'test.gif', 2, glitch_change=1)
     glitch_imgs[0].save('Collections/glitched_gif_increment.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],
@@ -281,7 +291,8 @@ def test_gif_to_gif():
     # glitch_amount will reach glitch_max after (glitch_max - glitch_amount)/glitch_change glitches
     # in this case that's 8
     # It'll cycle back to glitch_min after that and keep incrementing by glitch_change again
-    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif('test.gif', 2, glitch_change=1, cycle=True)
+    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif(
+        'test.gif', 2, glitch_change=1, cycle=True)
     glitch_imgs[0].save('Collections/glitched_gif_increment_cycle.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],
@@ -294,7 +305,8 @@ def test_gif_to_gif():
     # in this case that's 1
     # It'll cycle back to glitch_max after that and keep incrementing (actually decrementing, in this case)
     # by glitch_change again
-    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif('test.gif', 2, glitch_change=-1, cycle=True)
+    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif(
+        'test.gif', 2, glitch_change=-1, cycle=True)
     glitch_imgs[0].save('Collections/glitched_gif_decrement_cycle.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],
@@ -305,7 +317,8 @@ def test_gif_to_gif():
     # Now try with glitching only every 2nd frame
     # There will still be the same number of frames as in the source gif
     # But only every 2nd of the frames will be glitched
-    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif('test.gif', 2, step=2)
+    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif(
+        'test.gif', 2, step=2)
     glitch_imgs[0].save('Collections/glitched_gif_step.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],
@@ -315,7 +328,8 @@ def test_gif_to_gif():
 
     # Now try glitching with a seed
     # This will base the RNG used within the glitching on given seed
-    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif('test.gif', 2, seed=42)
+    glitch_imgs, src_duration, src_frames = glitcher.glitch_gif(
+        'test.gif', 2, seed=42)
     glitch_imgs[0].save('Collections/glitched_gif_seed.gif',
                         format='GIF',
                         append_images=glitch_imgs[1:],

--- a/test_script.py
+++ b/test_script.py
@@ -227,6 +227,115 @@ def test_image_to_gif():
                         loop=LOOP)
 
 
+def test_image_to_gif_frames():
+    """
+    Example of getting a glitched GIF and saving it as frames
+
+    We use glitch_level = 2 in this example
+    Please note you can use any number in between 1 and 10
+    Including floats, floats with one or two decimal precision
+    will work the best
+
+    We also are making infinitely looping GIFs
+    i.e loop = 0
+    You may change these to whatever you'd like
+    """
+
+    DURATION = (
+        200  # Set this to however many centiseconds each frame should be visible for
+    )
+    LOOP = 0  # Set this to how many times the gif should loop
+    # LOOP = 0 means infinite loop
+
+    # Make a directory to store the frames
+    if os.path.isdir("Collections/frames_test"):
+        shutil.rmtree("Collections/frames_test")
+    os.mkdir("Collections/frames_test")
+
+    # Loop over glitch_imgs and save each image as a PNG file
+    glitch_imgs = glitcher.glitch_image(f"test.{fmt}", 2, gif=True)
+    for i, img in enumerate(glitch_imgs):
+        img.save(f"Collections/frames_test/glitched_test_{i}.png")
+
+    # Now try with scan_lines set to true
+    glitch_imgs = glitcher.glitch_image(
+        f"test.{fmt}", 2, gif=True, scan_lines=True)
+    for i, img in enumerate(glitch_imgs):
+        img.save(f"Collections/frames_test/glitched_test_scan_{i}.png")
+
+    # Now try with color_offset set to true
+    glitch_imgs = glitcher.glitch_image(
+        f"test.{fmt}", 2, gif=True, color_offset=True)
+    for i, img in enumerate(glitch_imgs):
+        img.save(f"Collections/frames_test/glitched_test_color_{i}.png")
+
+    # Now try with 10 frames
+    glitch_imgs = glitcher.glitch_image(f"test.{fmt}", 2, gif=True, frames=10)
+    for i, img in enumerate(glitch_imgs):
+        img.save(f"Collections/frames_test/glitched_test_frames_{i}.png")
+
+    # Now try with increasing the glitch_amount by 1 every time, with cycle set to False
+    glitch_imgs = glitcher.glitch_image(
+        f"test.{fmt}", 2, glitch_change=1, gif=True)
+    for i, img in enumerate(glitch_imgs):
+        img.save(f"Collections/frames_test/glitched_test_increment_{i}.png")
+
+    # Now try with increasing the glitch_amount by 1 every time, with cycle set to True
+    glitch_imgs = glitcher.glitch_image(
+        f"test.{fmt}", 2, glitch_change=1, cycle=True, gif=True
+    )
+    for i, img in enumerate(glitch_imgs):
+        img.save(
+            f"Collections/frames_test/glitched_test_increment_cycle_{i}.png")
+
+    # Now try with increasing the glitch_amount by -1 every time, with cycle set to True
+    glitch_imgs = glitcher.glitch_image(
+        f"test.{fmt}", 2, glitch_change=-1, cycle=True, gif=True
+    )
+    for i, img in enumerate(glitch_imgs):
+        img.save(
+            f"Collections/frames_test/glitched_test_decrement_cycle_{i}.png")
+
+    # Now try with glitching only every 2nd frame
+    glitch_imgs = glitcher.glitch_image(f"test.{fmt}", 2, step=2, gif=True)
+    for i, img in enumerate(glitch_imgs):
+        img.save(f"Collections/frames_test/glitched_test_step_{i}.png")
+
+    # How about all of the above?
+    glitch_imgs = glitcher.glitch_image(
+        f"test.{fmt}",
+        2,
+        glitch_change=-1,
+        cycle=True,
+        gif=True,
+        scan_lines=True,
+        color_offset=True,
+        frames=10,
+        step=2,
+    )
+    glitch_imgs[0].save(
+        "Collections/glitched_test_all.gif",
+    )
+
+    # You can also pass an Image object inplace of the path
+    # Applicable in all of the examples above
+    img = Image.open(f"test.{fmt}")
+    glitch_imgs = glitcher.glitch_image(
+        img,
+        2,
+        glitch_change=-1,
+        cycle=True,
+        gif=True,
+        scan_lines=True,
+        color_offset=True,
+        frames=10,
+        step=2,
+    )
+    glitch_imgs[0].save(
+        "Collections/glitched_test_all_obj.gif",
+    )
+
+
 def test_gif_to_gif():
     """
      Example of getting a glitched GIF (from another GIF)
@@ -382,6 +491,12 @@ if __name__ == '__main__':
     test_image_to_image()
     t1 = time()
     print(f'Done! Time taken: {t1 - t0}')
+
+    print("Testing image to GIF frames glitching....")
+    t0 = time()
+    test_image_to_gif_frames()
+    t1 = time()
+    print(f"Done! Time taken: {t1 - t0}")
 
     print('Testing image to GIF glitching....')
     t0 = time()


### PR DESCRIPTION
I had an issue with transparency on the output gif, and needed the frames separately to use for a RainMeter animation anyways, so I modified the script to get them out if needed. I maintained the use as it was, the --output-frames flag is only considered if -g is set, should be backwards compatible